### PR TITLE
SS-4: Enables DBMI JWT request header authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,15 @@
+app/assets
+app/db.sqlite3
+app/error.log
+app/debug.log
+
+app/samplestore/local_settings.py
 app/__pycache__/*
 app/**/__pycache__/*
 
-app/assets
+samplestoredb-data/*
 
-app/db.sqlite3
-
-app/error.log
-app/debug.log
 debug.log
 error.log
-
 .DS_Store
-
-app/samplestore/local_settings.py
 docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ This app uses Django Rest Framework to expose an API for managing a collection o
 7. Run 'docker-compose build'
 8. Run 'docker-compose up'
 9. Go to http://0.0.0.0:8000
+
+## Authentication
+
+Sample Store uses DBMI's own py-auth0-jwt-rest pypi package to authenticate requests. This package expects that incoming requests to the Sample Store have an "Authorization" request header with a value of "JWT [jwt encoded string]". The package allows for this application to accept requests from multiple different Auth0 Client IDs within the greater HMS DBMI Auth0 account.
+
+## Permissions
+
+Object level permissions will be stored in DBMI's SciAuthZ microservice.

--- a/app/api/permissions.py
+++ b/app/api/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions
+from django.contrib.auth.models import User
+
+import logging
+logger = logging.getLogger(__name__)
+
+class IsAssociatedUser(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object to edit it.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return obj.user == request.user

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.models import User, Group
+from rest_framework import permissions
 from rest_framework import viewsets
-from django_filters.rest_framework import DjangoFilterBackend
+
+from api.permissions import IsAssociatedUser
 
 from api.serializers import SubjectSerializer
 from api.serializers import SampleTypeSerializer
@@ -31,50 +33,62 @@ from api.models import Interpretation
 class SubjectViewSet(viewsets.ModelViewSet):
     queryset = Subject.objects.all()
     serializer_class = SubjectSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
     filter_fields = ('external_id',)
 
 class SampleTypeViewSet(viewsets.ModelViewSet):
     queryset = SampleType.objects.all()
     serializer_class = SampleTypeSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class SampleViewSet(viewsets.ModelViewSet):
     queryset = Sample.objects.all()
     serializer_class = SampleSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
     filter_fields = ('subject__external_id',)
 
 class AliquotTypeViewSet(viewsets.ModelViewSet):
     queryset = AliquotType.objects.all()
     serializer_class = AliquotTypeSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AliquotQualityViewSet(viewsets.ModelViewSet):
     queryset = AliquotQuality.objects.all()
     serializer_class = AliquotQualitySerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AliquotViewSet(viewsets.ModelViewSet):
     queryset = Aliquot.objects.all()
     serializer_class = AliquotSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AssayTypeViewSet(viewsets.ModelViewSet):
     queryset = AssayType.objects.all()
     serializer_class = AssayTypeSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AssayStatusViewSet(viewsets.ModelViewSet):
     queryset = AssayStatus.objects.all()
     serializer_class = AssayStatusSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AssayViewSet(viewsets.ModelViewSet):
     queryset = Assay.objects.all()
     serializer_class = AssaySerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
     filter_fields = ('sample__subject__external_id',)
 
 class SequencingFileViewSet(viewsets.ModelViewSet):
     queryset = SequencingFile.objects.all()
     serializer_class = SequencingFileSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class AttachmentViewSet(viewsets.ModelViewSet):
     queryset = Attachment.objects.all()
     serializer_class = AttachmentSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)
 
 class InterpretationViewSet(viewsets.ModelViewSet):
     queryset = Interpretation.objects.all()
     serializer_class = InterpretationSerializer
+    permission_classes = (permissions.IsAuthenticated, IsAssociatedUser,)

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,5 +2,8 @@ Django==2.0
 djangorestframework==3.7.4
 django-filter==1.1.0
 mysqlclient==1.3.12
+py-auth0-jwt-rest==0.1.2
+PyJWT==1.4.2
+PyMySQL==0.7.9
 python-pstore==0.8
 pytz==2017.3

--- a/app/samplestore/settings.py
+++ b/app/samplestore/settings.py
@@ -120,6 +120,21 @@ TEMPLATES = [
 ]
 ########## END TEMPLATE CONFIGURATION
 
+########## APP CONFIGURATION
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'django_filters',
+    'api',
+    'pyauth0jwtrest',
+]
+########## END APP CONFIGURATION
+
 
 ########## MIDDLEWARE CONFIGURATION
 MIDDLEWARE = [
@@ -137,26 +152,6 @@ MIDDLEWARE = [
 ########## URL CONFIGURATION
 ROOT_URLCONF = 'samplestore.urls'
 ########## END URL CONFIGURATION
-
-
-########## APP CONFIGURATION
-DJANGO_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'django_filters',
-    'api',
-]
-
-LOCAL_APPS = [
-]
-
-INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS
-########## END APP CONFIGURATION
 
 
 ########## LOGGING CONFIGURATION
@@ -198,29 +193,38 @@ WSGI_APPLICATION = 'samplestore.wsgi.application'
 ########## END WSGI CONFIGURATION
 
 
-######## AUTH CONFIG
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-]
-##### END AUTH CONFIG
-
-
 ##### REST FRAMEWORK
 REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.DjangoModelPermissions'
+    ),
+    'PAGE_SIZE': 10,
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'pyauth0jwtrest.authentication.Auth0JSONWebTokenAuthentication',
+    ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
-##### END REST FRAMEWORK CONFIG
+###### END REST FRAMEWORK CONFIG
+
+###### AUTH CONFIG
+AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend') 
+
+AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
+AUTH0_CLIENT_ID = os.environ.get("AUTH0_CLIENT_ID")
+AUTH0_CLIENT_ID_LIST = os.environ.get("AUTH0_CLIENT_ID_LIST")
+AUTH0_SECRET = os.environ.get("AUTH0_SECRET")
+
+# Setting needed for py-auth0-jwt-rest package.
+AUTH0 = {
+    'CLIENT_ID': os.environ.get("AUTH0_CLIENT_ID"), # TODO PHASE OUT
+    'CLIENT_ID_LIST': os.environ.get("AUTH0_CLIENT_ID_LIST"),
+    'DOMAIN': os.environ.get("AUTH0_DOMAIN"),
+    'ALGORITHM': 'RS256',
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    'AUTHORIZATION_EXTENSION': False,
+}
+######
 
 try:
     from .local_settings import *


### PR DESCRIPTION
Leverages the latest version of DBMI's own py-auth0-jwt-rest package to handle DBMI JWT request header based authentication, which now accepts a list of accepted Auth0 Client IDs to enable authentication between Sample Store and the UDN+Sci-Services applications. Also adds very basic permissions for each ModelViewSet in the API, which will be changed later to use SciAuthZ for handling/tracking permissions.